### PR TITLE
Fixes #1066 collapsible widget

### DIFF
--- a/public-gui/src/components/CollapseField.jsx
+++ b/public-gui/src/components/CollapseField.jsx
@@ -17,8 +17,8 @@ export const CollapseField = ({title, info, children}) => {
                     <img src={collapse ?  caretUp: caretDown} className="caret" alt="caret"/>
                 </button>
             </div>
-            {(collapse && info) && <p className="collapsed" dangerouslySetInnerHTML={{__html: info}}/>}
-            {(collapse && !info) && <div className="collapsed">{children}</div>}
+            {(collapse && info) && <p className="collapse-field-content" dangerouslySetInnerHTML={{__html: info}}/>}
+            {(collapse && !info) && <div className="collapse-field-content">{children}</div>}
         </div>
     );
 }

--- a/public-gui/src/components/CollapseField.scss
+++ b/public-gui/src/components/CollapseField.scss
@@ -5,7 +5,7 @@
     width: 600px;
     margin: 8px 0;
     border-radius: 4px;
-    padding: 10px 20px 10px 10px;
+    padding: 10px 15px 10px 10px;
     cursor: pointer;
 
     @media (max-width: index.$mobile-width) {
@@ -22,10 +22,11 @@
         button {
             margin-left: auto;
             cursor: pointer;
+            padding: 5px;
         }
 
     }
-    .collapsed {
-        margin: 5px 0;
+    .collapse-field-content {
+        margin: 10px 0 5px 0;
     }
 }


### PR DESCRIPTION
#1066 

Minor style changes and using a button to open close (while remaining the onClick on the whole content)

<img width="639" height="66" alt="image" src="https://github.com/user-attachments/assets/fb6b76f9-521b-4f4d-906e-936bc42bcbdd" />

<img width="627" height="201" alt="image" src="https://github.com/user-attachments/assets/aedd1bdc-69d8-490e-bc33-07ae5a085072" />

Made the caret icon into a button, controllable with keyboard:
<img width="661" height="78" alt="image" src="https://github.com/user-attachments/assets/b5512b28-70ed-477f-887d-b6de0b01145c" />

<img width="744" height="175" alt="image" src="https://github.com/user-attachments/assets/a491c294-7fe3-4338-99ec-aef0c331aed4" />
