### PR TITLE
Typo in eduID deletion email

### DIFF
--- a/myconext-server/src/main/resources/mail_templates/inactivity_warning_short_term_en.html
+++ b/myconext-server/src/main/resources/mail_templates/inactivity_warning_short_term_en.html
@@ -11,7 +11,7 @@
     <div class="middle" style="padding: 20px 0 40px 60px;max-width: 600px;">
         <p>Dear <strong>{{name}}</strong>,</p>
         <p>We want to remind you that you have an eduID account that you haven't used for {{inactivity_period_en}}.
-            Please note: if you don't take any action, your eduID will be deleted in a {{deletion_period_en}}, on {{account_delete_date_en}}.
+            Please note: if you don't take any action, your eduID will be deleted in {{deletion_period_en}}, on {{account_delete_date_en}}.
         </p>
         {{> inactivity_services_en.html}}
         <p>

--- a/myconext-server/src/main/resources/mail_templates/inactivity_warning_short_term_en.txt
+++ b/myconext-server/src/main/resources/mail_templates/inactivity_warning_short_term_en.txt
@@ -1,6 +1,6 @@
 Dear {{name}},
 
-We want to remind you that you have an eduID account that you haven't used for {{inactivity_period_en}}. Please note: if you don't take any action, your eduID will be deleted in a {{deletion_period_en}}, on {{account_delete_date_en}}.
+We want to remind you that you have an eduID account that you haven't used for {{inactivity_period_en}}. Please note: if you don't take any action, your eduID will be deleted in {{deletion_period_en}}, on {{account_delete_date_en}}.
 
 {{> inactivity_services_en.txt}}
 

--- a/myconext-server/src/main/resources/mail_templates/inactivity_warning_short_term_nl.txt
+++ b/myconext-server/src/main/resources/mail_templates/inactivity_warning_short_term_nl.txt
@@ -1,6 +1,6 @@
 Beste {{name}},
 
-We willen je eraan herinneren dat je een eduID al {{inactivity_period_nl}} niet meer gebruikt hebt. Let op: doe je niets, dan wordt je eduID over een {{deletion_period_nl}} op {{account_delete_date_nl}} verwijderd.
+We willen je eraan herinneren dat je een eduID al {{inactivity_period_nl}} niet meer gebruikt hebt. Let op: doe je niets, dan wordt je eduID over {{deletion_period_nl}} op {{account_delete_date_nl}} verwijderd.
 
 {{> inactivity_services_nl.txt}}
 


### PR DESCRIPTION
The email says:
> Please note: if you don't take any action, your eduID will be deleted in a 1 week, on 2026 Apr 20.

`myconext-server/src/main/java/myconext/cron/InactivityMail.java` sets `1 week`, which doesn't play nice with the hardcoded `deleted in a`.

This removes `a/een` before `deletion_period_en` / `nl`, assuming it always starts with a number. I'm not sure if this is always true.