### PR TITLE
Add tiqr mfa registrations to metrics, rename apps to services. Fixes #1225

### DIFF
--- a/myconext-server/src/main/java/myconext/api/MetricsController.java
+++ b/myconext-server/src/main/java/myconext/api/MetricsController.java
@@ -27,9 +27,14 @@ public class MetricsController {
                 .description("Internal linked account count")
                 .register(meterRegistry);
 
-        Gauge.builder("registered_apps_count",
-                        () -> metricsRepository.countTotalRegisteredApps())
-                .description("Registered apps count")
+        Gauge.builder("app_registration_count",
+                        () -> metricsRepository.countTotalAppRegistrations())
+                .description("App registration count")
+                .register(meterRegistry);
+
+        Gauge.builder("used_services_count",
+                        () -> metricsRepository.countTotalUsedServices())
+                .description("Used services count")
                 .register(meterRegistry);
 
         Stream.of(IdpScoping.values())

--- a/myconext-server/src/main/java/myconext/repository/MetricsRepository.java
+++ b/myconext-server/src/main/java/myconext/repository/MetricsRepository.java
@@ -25,6 +25,13 @@ public class MetricsRepository {
                 ), "totalLinkedAccounts");
     }
 
+    public Integer countTotalAppRegistrations() {
+        return doInCollection("registrations",
+                List.of(
+                        "{ \"$count\": \"totalAppRegistrations\" }"
+                ), "totalAppRegistrations");
+    }
+
     public Integer countTotalExternalLinkedAccountsByType(IdpScoping idpScoping) {
         return doInCollection("users",
                 List.of(
@@ -32,6 +39,16 @@ public class MetricsRepository {
                         "{ \"$match\": { \"externalLinkedAccounts.idpScoping\": \"" + idpScoping.name() + "\" } },",
                         "{ \"$count\": \"countExternalLinkedAccounts\" }"
                 ), "countExternalLinkedAccounts");
+    }
+
+    public Integer countTotalUsedServices() {
+        return doInCollection("users",
+                List.of(
+                        "{ \"$unwind\": \"$eduIDS\" }",
+                        "{ \"$unwind\": \"$eduIDS.services\" }",
+                        "{ \"$group\": { \"_id\": \"$eduIDS.services.entityId\" } },",
+                        "{ \"$count\": \"countTotalUsedServices\" }"
+                ), "countTotalUsedServices");
     }
 
     public Integer countTotalRegisteredApps() {

--- a/myconext-server/src/main/java/myconext/repository/MetricsRepository.java
+++ b/myconext-server/src/main/java/myconext/repository/MetricsRepository.java
@@ -51,16 +51,6 @@ public class MetricsRepository {
                 ), "countTotalUsedServices");
     }
 
-    public Integer countTotalRegisteredApps() {
-        return doInCollection("users",
-                List.of(
-                        "{ \"$unwind\": \"$eduIDS\" }",
-                        "{ \"$unwind\": \"$eduIDS.services\" }",
-                        "{ \"$group\": { \"_id\": \"$eduIDS.services.entityId\" } },",
-                        "{ \"$count\": \"countTotalRegisteredApps\" }"
-                ), "countTotalRegisteredApps");
-    }
-
     private Integer doInCollection(String collectionName, List<String> pipeLines, String resultKeyWord) {
         return mongoTemplate.execute(collectionName, collection -> {
             List<Document> documents = pipeLines

--- a/myconext-server/src/test/java/myconext/api/MetricsControllerTest.java
+++ b/myconext-server/src/test/java/myconext/api/MetricsControllerTest.java
@@ -33,7 +33,7 @@ class MetricsControllerTest {
 
         String metrics = IOUtils.toString(inputStream, Charset.defaultCharset());
 
-        List.of("user_count", "linked_account_count", "registered_apps_count")
+        List.of("user_count", "linked_account_count", "app_registration_count", "used_services_count")
                 .forEach(s -> assertTrue(metrics.contains(s)));
         Stream.of(IdpScoping.values()).forEach(idpScoping ->
                 assertTrue(metrics.contains("external_linked_account_" + idpScoping.name())));

--- a/myconext-server/src/test/java/myconext/repository/MetricsRepositoryTest.java
+++ b/myconext-server/src/test/java/myconext/repository/MetricsRepositoryTest.java
@@ -18,8 +18,8 @@ class MetricsRepositoryTest extends AbstractIntegrationTest {
         assertEquals(2, totalLinkedAccountCount);
         Integer idinExternalAccounts = metricsRepository.countTotalExternalLinkedAccountsByType(IdpScoping.idin);
         assertEquals(0, idinExternalAccounts);
-        Integer countTotalRegisteredApps = metricsRepository.countTotalRegisteredApps();
-        assertEquals(2, countTotalRegisteredApps);
+        Integer countTotalUsedServices = metricsRepository.countTotalUsedServices();
+        assertEquals(2, countTotalUsedServices);
     }
 
 }


### PR DESCRIPTION
The metric `registered_apps_count` was counting the services where an eduID was used. The number of MFA app registrations was missing. This renames the `registered_apps_count` to `used_services_count` and adds a `app_registration_count`

Testing can be done by opening https://login.<domain\>/internal/prometheus and looking for the new values.


