### PR TITLE
Updates login url, this is at least used by the public website

### DIFF
--- a/myconext-server/src/main/java/myconext/api/LoginController.java
+++ b/myconext-server/src/main/java/myconext/api/LoginController.java
@@ -131,7 +131,7 @@ public class LoginController {
         this.createFromInstitutionAllowedReturnDomains = createFromInstitutionProperties.getReturnUrlAllowedDomains();
         this.spBaseUrl = spBaseUrl;
         this.spServiceDeskBaseUrl = spServiceDeskBaseUrl;
-        this.myconextLoginUrl = myConextUrl + "/oauth2/authorization/oidcng";
+        this.myconextLoginUrl = myConextUrl + "/oauth2/authorization/my_conext";
     }
 
     @GetMapping("/config")

--- a/myconext-server/src/test/java/myconext/api/LoginControllerTest.java
+++ b/myconext-server/src/test/java/myconext/api/LoginControllerTest.java
@@ -144,7 +144,7 @@ public class LoginControllerTest extends AbstractIntegrationTest {
                 .get("/register")
                 .then()
                 .statusCode(302)
-                .header("Location", "https://my.test2.surfconext.nl/oauth2/authorization/oidcng?lang=en");
+                .header("Location", "https://my.test2.surfconext.nl/oauth2/authorization/my_conext?lang=en");
     }
 
     @Test


### PR DESCRIPTION
Fix for Create an eduID url on public page. The server had the old redirect url still configured.