### PR TITLE
#1032 iap acr values

### DIFF
--- a/account-gui/src/App.svelte
+++ b/account-gui/src/App.svelte
@@ -24,6 +24,7 @@
     import Stepup from "./routes/Stepup.svelte";
     import AffiliationMissing from "./routes/AffiliationMissing.svelte";
     import ValidNameMissing from "./routes/ValidNameMissing.svelte";
+    import IapAssuranceMissing from "./routes/IapAssuranceMissing.svelte";
     import EppnAlreadyLinked from "./routes/EppnAlreadyLinked.svelte";
     import Request from "./routes/Request.svelte";
     import SubContent from "./components/SubContent.svelte";
@@ -203,6 +204,9 @@
                 </Route>
                 <Route path="/valid-name-missing/:id" let:params>
                     <ValidNameMissing id="{params.id}"/>
+                </Route>
+                <Route path="/iap-assurance-missing/:id" let:params>
+                    <IapAssuranceMissing id="{params.id}"/>
                 </Route>
                 <Route path="/eppn-already-linked/:id" let:params>
                     <EppnAlreadyLinked id="{params.id}"/>

--- a/account-gui/src/locale/en.js
+++ b/account-gui/src/locale/en.js
@@ -882,6 +882,15 @@ const en = {
     "ProceedLink": "Proceed",
     "RetryLink": "Retry"
   },
+  "IapAssuranceMissing": {
+    "Header": "Account is connected, but…",
+    "Info": "Your eduID is successfully connected, however the institution you choose did not provide the required {{level}} level of assurance.",
+    "LevelHigh": "High",
+    "LevelMedium": "Medium",
+    "Proceed": "You can try to verify your identity via another trusted party or proceed to {{name}}.",
+    "ProceedLink": "Proceed",
+    "RetryLink": "Retry"
+  },
   "StepUpExplanation": {
     "Info": " ",
     "Linked_institution": "Your eduID must be connected to an official institution where you are a student.",

--- a/account-gui/src/locale/en.js
+++ b/account-gui/src/locale/en.js
@@ -888,7 +888,8 @@ const en = {
     "Validate_names": "Your first name and last name must be verified by an official party.",
     "Validate_names_external": "Your identity must be verified by a trusted party.",
     "Affiliation_student": "You need to prove that you are enrolled in education. You can do this by connecting your eduID to an official institution.",
-    "Profile_mfa": "You must log in using the eduID app for multi-factor authentication."
+    "Profile_mfa": "You must log in using the eduID app for multi-factor authentication.",
+    "Any_link": "Your eduID account must be linked to a trusted party, such as your institution, bank or eHerkenning."
   },
   "StepUpVerification": {
     "Info": " ",
@@ -896,7 +897,8 @@ const en = {
     "Validate_names": "Your first name and last name are verified by an official party.",
     "Validate_names_external": "Your identity is verified by a trusted party.",
     "Affiliation_student": "You have proven that you are following education by connecting your eduID account to an official party.",
-    "Profile_mfa": "You have successfully logged in using the eduID app with multi-factor authentication."
+    "Profile_mfa": "You have successfully logged in using the eduID app with multi-factor authentication.",
+    "Any_link": "Your eduID account is linked to a trusted party."
   },
   "NudgeApp": {
     "New": "Your eduID has been created",

--- a/account-gui/src/locale/nl.js
+++ b/account-gui/src/locale/nl.js
@@ -888,7 +888,8 @@ const nl = {
     "Validate_names": "Je voornaam en achternaam moeten worden bevestigd door een officiële instelling.",
     "Validate_names_external": "Je voornaam en achternaam moeten worden geverifieerd door een externe vertrouwde instelling.",
     "Affiliation_student": "Je moet aantonen dat je student bent. Dit doe je door je eduID te koppelen aan een officiële instelling.",
-    "Profile_mfa": "Je moet inloggen met de eduID app voor multi-factor authenticatie."
+    "Profile_mfa": "Je moet inloggen met de eduID app voor multi-factor authenticatie.",
+    "Any_link": "Je eduID-account moet gekoppeld zijn aan een vertrouwde partij, zoals je instelling, bank of eHerkenning."
   },
   "StepUpVerification": {
     "Info": " ",
@@ -896,7 +897,8 @@ const nl = {
     "Validate_names": "Je voornaam en achternaam zijn bevestigd door een officiële instelling.",
     "Validate_names_external": "Je voornaam en achternaam moeten worden geverifieerd door een externe vertrouwde instelling.",
     "Affiliation_student": "Je hebt aangetoond dat je student bent, doordat je eduID is gekoppeld aan een officiële instelling.",
-    "Profile_mfa": "Je bent succesvol ingelogd met de eduID app met multi-factor authenticatie."
+    "Profile_mfa": "Je bent succesvol ingelogd met de eduID app met multi-factor authenticatie.",
+    "Any_link": "Je eduID-account is gekoppeld aan een vertrouwde partij."
   },
   "NudgeApp": {
     "New": "Je eduID is aangemaakt",

--- a/account-gui/src/locale/nl.js
+++ b/account-gui/src/locale/nl.js
@@ -882,6 +882,15 @@ const nl = {
     "ProceedLink": "Doorgaan",
     "RetryLink": "Opnieuw proberen"
   },
+  "IapAssuranceMissing": {
+    "Header": "Account is gekoppeld, maar…",
+    "Info": "Je eduID is succesvol gekoppeld, maar de instelling die je hebt gekozen heeft niet het vereiste betrouwbaarheidsniveau {{level}} teruggegeven.",
+    "LevelHigh": "Hoog",
+    "LevelMedium": "Midden",
+    "Proceed": "Je kan proberen je identiteit via een andere vertrouwde partij te verifiëren of doorgaan naar {{name}}.",
+    "ProceedLink": "Doorgaan",
+    "RetryLink": "Opnieuw proberen"
+  },
   "StepUpExplanation": {
     "Info": " ",
     "Linked_institution": "Je eduID moet gekoppeld zijn aan een officiële instelling waar je student bent.",

--- a/account-gui/src/routes/IapAssuranceMissing.svelte
+++ b/account-gui/src/routes/IapAssuranceMissing.svelte
@@ -1,0 +1,72 @@
+<script>
+    import I18n from "../locale/I18n";
+    import {onMount} from 'svelte';
+    import {conf, links} from "../stores/conf";
+    import Button from "../components/Button.svelte";
+    import Spinner from "../components/Spinner.svelte";
+    import {fetchServiceName} from "../api";
+    import {proceed} from "../utils/sso";
+
+    export let id;
+    let serviceName = null;
+    let showSpinner = true;
+    let level = "high";
+
+    onMount(() => {
+        $links.displayBackArrow = false;
+
+        const urlSearchParams = new URLSearchParams(window.location.search);
+        level = urlSearchParams.get("level") === "medium" ? "medium" : "high";
+
+        fetchServiceName(id).then(res => {
+            serviceName = res.name;
+            showSpinner = false;
+        });
+    });
+
+    const retry = () => {
+        //The institution link already failed to provide the required assurance level, so only offer the external options
+        window.location.href = `/stepup/${id}?retry=true`;
+    };
+
+    $: levelLabel = I18n.t(level === "medium" ? "IapAssuranceMissing.LevelMedium" : "IapAssuranceMissing.LevelHigh");
+
+</script>
+
+<style>
+
+
+    h2 {
+        margin: 30px 0 40px 0;
+        font-size: 32px;
+        color: var(--color-primary-green);
+    }
+
+    p.info {
+        margin-bottom: 25px;
+    }
+
+    div.last {
+        margin-top: 25px;
+    }
+
+</style>
+{#if showSpinner}
+    <Spinner/>
+{/if}
+<div class="home">
+    <div class="card">
+        <h2>{I18n.t("IapAssuranceMissing.Header")}</h2>
+        <p class="info">{I18n.t("IapAssuranceMissing.Info", {level: levelLabel})}</p>
+        <p class="info">{I18n.t("IapAssuranceMissing.Proceed", {name: serviceName})}</p>
+
+        <Button href="/proceed" onClick={() => proceed($conf.magicLinkUrl)}
+                className="cancel"
+                label={I18n.t("Profile.Proceed")}/>
+        <div class="last">
+            <Button href="/retry" onClick={retry}
+                    label={I18n.t("EppnAlreadyLinked.RetryButton")}/>
+        </div>
+
+    </div>
+</div>

--- a/myconext-server/src/main/java/myconext/api/AccountLinkerController.java
+++ b/myconext-server/src/main/java/myconext/api/AccountLinkerController.java
@@ -70,6 +70,7 @@ import java.util.stream.Stream;
 import static myconext.crypto.HashGenerator.hash;
 import static myconext.log.MDCContext.logWithContext;
 import static myconext.security.CookieResolver.cookieByName;
+import static myconext.security.GuestIdpAuthenticationRequestFilter.hasRequiredIapAssurance;
 import static myconext.security.GuestIdpAuthenticationRequestFilter.hasRequiredStudentAffiliation;
 import static myconext.security.GuestIdpAuthenticationRequestFilter.hasValidatedName;
 import static org.springframework.security.web.context.HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY;
@@ -395,6 +396,8 @@ public class AccountLinkerController implements UserAuthentication {
                 null,
                 null,
                 null,
+                null,
+                Collections.emptyList(),
                 null,
                 userInfo);
         requestInstitutionEduIDRepository.save(requestInstitutionEduID);
@@ -790,7 +793,8 @@ public class AccountLinkerController implements UserAuthentication {
 
         return doRedirect(code, user, this.spFlowRedirectUri, this.myconextRedirectUrl + "/personal",
                 false, false, true, null, null,
-                this.myconextRedirectUrl + "/eppn-already-linked", this.myconextRedirectUrl + "/attribute-missing");
+                this.myconextRedirectUrl + "/eppn-already-linked", this.myconextRedirectUrl + "/attribute-missing",
+                Collections.emptyList(), null);
     }
 
     @GetMapping("/mobile/oidc/redirect")
@@ -813,7 +817,8 @@ public class AccountLinkerController implements UserAuthentication {
 
         return doRedirect(code, user, this.mobileFlowRedirectUri, this.accountRedirectUrl + "/client/mobile/account-linked",
                 false, false, true, null, null,
-                this.accountRedirectUrl + "/client/mobile/eppn-already-linked", this.accountRedirectUrl + "/client/mobile/attribute-missing");
+                this.accountRedirectUrl + "/client/mobile/eppn-already-linked", this.accountRedirectUrl + "/client/mobile/attribute-missing",
+                Collections.emptyList(), null);
     }
 
     @GetMapping("/idp/oidc/redirect")
@@ -855,6 +860,13 @@ public class AccountLinkerController implements UserAuthentication {
                 "?h=" + samlAuthenticationRequest.getHash() +
                 "&redirect=" + URLEncoder.encode(this.magicLinkUrl, charSet);
 
+        boolean iapHighRequired = ACR.containsAcr(samlAuthenticationRequest.getAuthenticationContextClassReferences(), ACR.IAP_HIGH);
+        String idpIapAssuranceRequiredUri = this.accountRedirectUrl + "/iap-assurance-missing/" +
+                samlAuthenticationRequest.getId() +
+                "?h=" + samlAuthenticationRequest.getHash() +
+                "&redirect=" + URLEncoder.encode(this.magicLinkUrl, charSet) +
+                "&level=" + (iapHighRequired ? "high" : "medium");
+
         String eppnAlreadyLinkedRequiredUri = this.accountRedirectUrl + "/eppn-already-linked/" +
                 samlAuthenticationRequest.getId() +
                 "?h=" + samlAuthenticationRequest.getHash() +
@@ -866,7 +878,8 @@ public class AccountLinkerController implements UserAuthentication {
                 "&redirect=" + URLEncoder.encode(this.magicLinkUrl, charSet);
 
         ResponseEntity redirect = doRedirect(code, user, this.idpFlowRedirectUri, location, validateNames, studentAffiliationRequired, false,
-                idpStudentAffiliationRequiredUri, idpValidNamesRequiredUri, eppnAlreadyLinkedRequiredUri, attributeMissingUri);
+                idpStudentAffiliationRequiredUri, idpValidNamesRequiredUri, eppnAlreadyLinkedRequiredUri, attributeMissingUri,
+                samlAuthenticationRequest.getAuthenticationContextClassReferences(), idpIapAssuranceRequiredUri);
 
         StepUpStatus stepUpStatus = redirect.getHeaders().getLocation()
                 .toString().contains("affiliation-missing") ? StepUpStatus.MISSING_AFFILIATION : StepUpStatus.IN_STEP_UP;
@@ -887,13 +900,16 @@ public class AccountLinkerController implements UserAuthentication {
                                       String idpStudentAffiliationRequiredUri,
                                       String idpValidNamesRequiredUri,
                                       String eppnAlreadyLinkedRequiredUri,
-                                      String attributeMissingUri) throws UnsupportedEncodingException {
+                                      String attributeMissingUri,
+                                      List<String> authenticationContextClassReferences,
+                                      String idpIapAssuranceRequiredUri) throws UnsupportedEncodingException {
         Map<String, Object> body = requestUserInfo(code, oidcRedirectUri);
 
         LOG.info(String.format("In redirect link account for user %s with user info %s", user.getEmail(), body));
 
         return saveOrUpdateLinkedAccountToUser(user, clientRedirectUri, validateNames, studentAffiliationRequired,
-                appendEPPNQueryParam, idpStudentAffiliationRequiredUri, idpValidNamesRequiredUri, eppnAlreadyLinkedRequiredUri, attributeMissingUri, body);
+                appendEPPNQueryParam, idpStudentAffiliationRequiredUri, idpValidNamesRequiredUri, eppnAlreadyLinkedRequiredUri, attributeMissingUri,
+                authenticationContextClassReferences, idpIapAssuranceRequiredUri, body);
     }
 
     private ResponseEntity<Object> saveOrUpdateLinkedAccountToUser(User user,
@@ -905,6 +921,8 @@ public class AccountLinkerController implements UserAuthentication {
                                                                    String idpValidNamesRequiredUri,
                                                                    String eppnAlreadyLinkedRequiredUri,
                                                                    String attributeMissingUri,
+                                                                   List<String> authenticationContextClassReferences,
+                                                                   String idpIapAssuranceRequiredUri,
                                                                    Map<String, Object> body) throws UnsupportedEncodingException {
         String eppn = (String) body.get("eduperson_principal_name");
         String subjectId = (String) body.get("subject_id");
@@ -968,6 +986,11 @@ public class AccountLinkerController implements UserAuthentication {
         if (validateNames && !hasValidNames) {
             //Corner case where the user has been stepped Up, but there is no valid name
             return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(idpValidNamesRequiredUri)).build();
+        }
+
+        if (!hasRequiredIapAssurance(user, authenticationContextClassReferences)) {
+            //Corner case where the user has been stepped up to link an institution, but that institution did not assert the required IAP Medium / High assurance level
+            return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(idpIapAssuranceRequiredUri)).build();
         }
 
         if (appendEPPNQueryParam) {

--- a/myconext-server/src/main/java/myconext/security/ACR.java
+++ b/myconext-server/src/main/java/myconext/security/ACR.java
@@ -7,6 +7,17 @@ import java.util.List;
 
 public class ACR {
 
+    // Dev notes:
+    // New user + ACR HIGH --> any_link
+    // Existing user without institution link + ACR HIGH --> any_link
+    //
+    // (Note: do close in private window after linking)
+    // Existing user with institution link + ACR HIGH --> any_link
+    // Existing user with high assurance + ACR HIGH --> NO STEPUP
+    //
+    // Extra:
+    // User with any_link but fails to get HIGH assurance --> validated external only
+
     private ACR() {
     }
 
@@ -63,11 +74,15 @@ public class ACR {
     public static String selectACR(List<String> acrValues, boolean studentAffiliationPresent) {
         List<String> priorityOrder = Arrays.asList(
             VALIDATE_NAMES_EXTERNAL_MFA,
+            IAP_HIGH_MFA,
+            IAP_MEDIUM_MFA,
             VALIDATE_NAMES_MFA,
             AFFILIATION_STUDENT_MFA,
             LINKED_INSTITUTION_MFA,
             PROFILE_MFA,
             VALIDATE_NAMES_EXTERNAL,
+            IAP_HIGH,
+            IAP_MEDIUM,
             VALIDATE_NAMES,
             AFFILIATION_STUDENT,
             LINKED_INSTITUTION
@@ -119,9 +134,15 @@ public class ACR {
 
         return acrValues.stream().anyMatch(acr -> acr.endsWith(MFA));
     }
-
     public static String explanationKeyWord(List<String> acrValues, boolean studentAffiliationPresent) {
-        if (CollectionUtils.isEmpty(acrValues) || containsAcr(acrValues, LINKED_INSTITUTION)) {
+        if (CollectionUtils.isEmpty(acrValues)) {
+            return "linked_institution";
+        }
+        // HIGH can also be IdP-asserted; do not force external validation — frontend handles any_link
+        if (containsAcr(acrValues, IAP_HIGH) || containsAcr(acrValues, IAP_MEDIUM)) {
+            return "any_link";
+        }
+        if (containsAcr(acrValues, LINKED_INSTITUTION)) {
             return "linked_institution";
         }
         if (containsAcr(acrValues, PROFILE_MFA)) {

--- a/myconext-server/src/main/java/myconext/security/ACR.java
+++ b/myconext-server/src/main/java/myconext/security/ACR.java
@@ -16,6 +16,8 @@ public class ACR {
     public static String VALIDATE_NAMES = "https://eduid.nl/trust/validate-names";
     public static String VALIDATE_NAMES_EXTERNAL = "https://eduid.nl/trust/validate-names-external";
     public static String AFFILIATION_STUDENT = "https://eduid.nl/trust/affiliation-student";
+    public static String IAP_MEDIUM = "https://refeds.org/assurance/IAP/medium";
+    public static String IAP_HIGH = "https://refeds.org/assurance/IAP/high";
 
     public static String PROFILE_MFA = "https://refeds.org/profile/mfa";
 
@@ -23,29 +25,39 @@ public class ACR {
     public static String VALIDATE_NAMES_MFA = "https://eduid.nl/trust/validate-names/mfa";
     public static String VALIDATE_NAMES_EXTERNAL_MFA = "https://eduid.nl/trust/validate-names-external/mfa";
     public static String AFFILIATION_STUDENT_MFA = "https://eduid.nl/trust/affiliation-student/mfa";
+    public static String IAP_MEDIUM_MFA = "https://refeds.org/assurance/IAP/medium/mfa";
+    public static String IAP_HIGH_MFA = "https://refeds.org/assurance/IAP/high/mfa";
 
     public static List<String> allAccountLinkingContextClassReferences() {
-        return Arrays.asList(VALIDATE_NAMES, VALIDATE_NAMES_EXTERNAL, LINKED_INSTITUTION, AFFILIATION_STUDENT);
+        return Arrays.asList(VALIDATE_NAMES, VALIDATE_NAMES_EXTERNAL, LINKED_INSTITUTION, AFFILIATION_STUDENT, IAP_MEDIUM, IAP_HIGH);
     }
 
     public static void initialize(String linkedInstitution,
                                   String validateNames,
                                   String externalValidateNames,
                                   String affiliationStudent,
+                                  String iapMedium,
+                                  String iapHigh,
                                   String profileMfa,
                                   String linkedInstitutionMfa,
                                   String validateNamesMfa,
                                   String externalValidateNamesMfa,
-                                  String affiliationStudentMfa) {
+                                  String affiliationStudentMfa,
+                                  String iapMediumMfa,
+                                  String iapHighMfa) {
         LINKED_INSTITUTION = linkedInstitution;
         VALIDATE_NAMES = validateNames;
         VALIDATE_NAMES_EXTERNAL = externalValidateNames;
         AFFILIATION_STUDENT = affiliationStudent;
+        IAP_MEDIUM = iapMedium;
+        IAP_HIGH = iapHigh;
         PROFILE_MFA = profileMfa;
         LINKED_INSTITUTION_MFA = linkedInstitutionMfa;
         VALIDATE_NAMES_MFA = validateNamesMfa;
         VALIDATE_NAMES_EXTERNAL_MFA = externalValidateNamesMfa;
         AFFILIATION_STUDENT_MFA = affiliationStudentMfa;
+        IAP_MEDIUM_MFA = iapMediumMfa;
+        IAP_HIGH_MFA = iapHighMfa;
     }
 
     public static String selectACR(List<String> acrValues, boolean studentAffiliationPresent) {

--- a/myconext-server/src/main/java/myconext/security/ACR.java
+++ b/myconext-server/src/main/java/myconext/security/ACR.java
@@ -7,17 +7,6 @@ import java.util.List;
 
 public class ACR {
 
-    // Dev notes:
-    // New user + ACR HIGH --> any_link
-    // Existing user without institution link + ACR HIGH --> any_link
-    //
-    // (Note: do close in private window after linking)
-    // Existing user with institution link + ACR HIGH --> any_link
-    // Existing user with high assurance + ACR HIGH --> NO STEPUP
-    //
-    // Extra:
-    // User with any_link but fails to get HIGH assurance --> validated external only
-
     private ACR() {
     }
 
@@ -138,7 +127,6 @@ public class ACR {
         if (CollectionUtils.isEmpty(acrValues)) {
             return "linked_institution";
         }
-        // HIGH can also be IdP-asserted; do not force external validation — frontend handles any_link
         if (containsAcr(acrValues, IAP_HIGH) || containsAcr(acrValues, IAP_MEDIUM)) {
             return "any_link";
         }

--- a/myconext-server/src/main/java/myconext/security/GuestIdpAuthenticationRequestFilter.java
+++ b/myconext-server/src/main/java/myconext/security/GuestIdpAuthenticationRequestFilter.java
@@ -361,7 +361,21 @@ public class GuestIdpAuthenticationRequestFilter extends OncePerRequestFilter {
                 validatedName;
         boolean linkedInstitutionMissing = ACR.containsAcr(authenticationContextClassReferenceValues, ACR.LINKED_INSTITUTION) &&
                 nonExpiredLinkedAccounts.isEmpty();
-        return atLeastOneNotExpired && hasRequiredStudentAffiliation && hasValidatedNames && !linkedInstitutionMissing;
+        return atLeastOneNotExpired && hasRequiredStudentAffiliation && hasValidatedNames && !linkedInstitutionMissing &&
+                hasRequiredIapAssurance(user, authenticationContextClassReferenceValues);
+    }
+
+    private boolean hasRequiredIapAssurance(User user, List<String> authenticationContextClassReferenceValues) {
+        boolean highRequired = ACR.containsAcr(authenticationContextClassReferenceValues, ACR.IAP_HIGH);
+        boolean mediumRequired = ACR.containsAcr(authenticationContextClassReferenceValues, ACR.IAP_MEDIUM);
+        if (!highRequired && !mediumRequired) {
+            return true;
+        }
+        List<String> assurances = eduPersonAssurances(user);
+        if (highRequired) {
+            return assurances.contains(ACR.IAP_HIGH);
+        }
+        return assurances.contains(ACR.IAP_MEDIUM);
     }
 
     public static boolean hasValidatedName(User user) {
@@ -379,6 +393,7 @@ public class GuestIdpAuthenticationRequestFilter extends OncePerRequestFilter {
                 .anyMatch(affiliation -> affiliation.toLowerCase().contains("student"));
     }
 
+    // Contains a list of requested ACR's -- "What does the SP require the user to be"
     private List<String> getAuthenticationContextClassReferenceValues(AuthnRequest authenticationRequest) {
         RequestedAuthnContext requestedAuthnContext = authenticationRequest.getRequestedAuthnContext();
         if (requestedAuthnContext == null) {
@@ -517,12 +532,19 @@ public class GuestIdpAuthenticationRequestFilter extends OncePerRequestFilter {
                 (CollectionUtils.isEmpty(user.getLinkedAccounts()) || user.getLinkedAccounts().stream()
                         .allMatch(linkedAccount -> now.isAfter(linkedAccount.getExpiresAt().toInstant())));
 
+        boolean missingIapAssurance = !hasRequiredIapAssurance(user, authenticationContextClassReferences);
+
         if (user.isNewUser()) {
             user.setNewUser(false);
             userRepository.save(user);
 
             logWithContext(user, "add", "account", LOG, "Saving user after new registration and magic link");
             mailBox.sendAccountConfirmation(user);
+
+            if(missingIapAssurance) {
+                return false;
+            }
+
             if (inStepUpFlow) {
                 finishStepUp(samlAuthenticationRequest);
             }
@@ -539,6 +561,9 @@ public class GuestIdpAuthenticationRequestFilter extends OncePerRequestFilter {
             response.sendRedirect(url);
             return false;
         } else if (inStepUpFlow) {
+            if (missingIapAssurance) {
+                return false;
+            }
             finishStepUp(samlAuthenticationRequest);
             if (missingStudentAffiliation || missingValidName || missingLinkedInstitution) {
                 //When we send the assertion, EB stops the flow, but this will be fixed upstream
@@ -608,6 +633,7 @@ public class GuestIdpAuthenticationRequestFilter extends OncePerRequestFilter {
         List<String> authenticationContextClassReferences = samlAuthenticationRequest.getAuthenticationContextClassReferences();
         String explanation = ACR.explanationKeyWord(authenticationContextClassReferences, hasStudentAffiliation);
 
+        // Performs check if ACR is coorrect
         boolean proceed = this.checkStepUp(response, request, samlAuthenticationRequest.getHash(), samlAuthenticationRequest, user, charSet, explanation);
         if (!proceed) {
             return;
@@ -903,7 +929,7 @@ public class GuestIdpAuthenticationRequestFilter extends OncePerRequestFilter {
                         samlAttribute.getValue().equals("student"))) {
             attributes.add(attribute("urn:mace:dir:attribute-def:eduPersonAffiliation", "student"));
         }
-        List<String> eduPersonAssurances = eduPersonAssurances(user);
+        List<String> eduPersonAssurances = eduPersonAssurances(user); // Todo: needs to be called earlier -- we need to do the check ACR matches
         eduPersonAssurances
                 .forEach(eduPersonAssurance -> attributes.add(attribute("urn:mace:dir:attribute-def:eduPersonAssurance", eduPersonAssurance)));
         // lastLogin is updated, possible an new eduID value or deleted affiliations

--- a/myconext-server/src/main/java/myconext/security/GuestIdpAuthenticationRequestFilter.java
+++ b/myconext-server/src/main/java/myconext/security/GuestIdpAuthenticationRequestFilter.java
@@ -394,7 +394,6 @@ public class GuestIdpAuthenticationRequestFilter extends OncePerRequestFilter {
                 .anyMatch(affiliation -> affiliation.toLowerCase().contains("student"));
     }
 
-    // Contains a list of requested ACR's -- "What does the SP require the user to be"
     private List<String> getAuthenticationContextClassReferenceValues(AuthnRequest authenticationRequest) {
         RequestedAuthnContext requestedAuthnContext = authenticationRequest.getRequestedAuthnContext();
         if (requestedAuthnContext == null) {
@@ -627,7 +626,6 @@ public class GuestIdpAuthenticationRequestFilter extends OncePerRequestFilter {
         List<String> authenticationContextClassReferences = samlAuthenticationRequest.getAuthenticationContextClassReferences();
         String explanation = ACR.explanationKeyWord(authenticationContextClassReferences, hasStudentAffiliation);
 
-        // Performs check if ACR is coorrect
         boolean proceed = this.checkStepUp(response, request, samlAuthenticationRequest.getHash(), samlAuthenticationRequest, user, charSet, explanation);
         if (!proceed) {
             return;

--- a/myconext-server/src/main/java/myconext/security/GuestIdpAuthenticationRequestFilter.java
+++ b/myconext-server/src/main/java/myconext/security/GuestIdpAuthenticationRequestFilter.java
@@ -541,14 +541,10 @@ public class GuestIdpAuthenticationRequestFilter extends OncePerRequestFilter {
             logWithContext(user, "add", "account", LOG, "Saving user after new registration and magic link");
             mailBox.sendAccountConfirmation(user);
 
-            if(missingIapAssurance) {
-                return false;
-            }
-
             if (inStepUpFlow) {
                 finishStepUp(samlAuthenticationRequest);
             }
-            if (missingStudentAffiliation || missingValidName || missingLinkedInstitution) {
+            if (missingStudentAffiliation || missingValidName || missingLinkedInstitution || missingIapAssurance) {
                 //When we send the assertion, EB stops the flow, but this will be fixed upstream
                 return true;
             }
@@ -561,11 +557,8 @@ public class GuestIdpAuthenticationRequestFilter extends OncePerRequestFilter {
             response.sendRedirect(url);
             return false;
         } else if (inStepUpFlow) {
-            if (missingIapAssurance) {
-                return false;
-            }
             finishStepUp(samlAuthenticationRequest);
-            if (missingStudentAffiliation || missingValidName || missingLinkedInstitution) {
+            if (missingStudentAffiliation || missingValidName || missingLinkedInstitution || missingIapAssurance) {
                 //When we send the assertion, EB stops the flow, but this will be fixed upstream
                 return true;
             }
@@ -766,7 +759,9 @@ public class GuestIdpAuthenticationRequestFilter extends OncePerRequestFilter {
                     (CollectionUtils.isEmpty(user.getLinkedAccounts()) || user.getLinkedAccounts().stream()
                             .allMatch(linkedAccount -> now.isAfter(linkedAccount.getExpiresAt().toInstant())));
 
-            if (missingStudentAffiliation || missingValidName || missingExternalName || missingLinkedInstitution) {
+            boolean missingIapAssurance = !hasRequiredIapAssurance(user, authenticationContextClassReferences);
+
+            if (missingStudentAffiliation || missingValidName || missingExternalName || missingLinkedInstitution || missingIapAssurance) {
                 if (missingValidName) {
                     optionalMessage = "The requesting service has indicated that the authenticated user is required to have a first_name and last_name." +
                             " Your institution has not provided those attributes.";
@@ -776,6 +771,9 @@ public class GuestIdpAuthenticationRequestFilter extends OncePerRequestFilter {
                 } else if (missingLinkedInstitution) {
                     optionalMessage = "The requesting service has indicated that the authenticated user has linked its account to an Institution." +
                             " Your identity is not verified by an external educational institution.";
+                } else if (missingIapAssurance) {
+                    optionalMessage = "The requesting service has indicated that the authenticated user is required to have a certain level of identity assurance." +
+                            " Your institution has not provided the required assurance level.";
                 } else {
                     optionalMessage = "The requesting service has indicated that the authenticated user is required to have an affiliation Student." +
                             " Your institution has not provided this affiliation.";

--- a/myconext-server/src/main/java/myconext/security/GuestIdpAuthenticationRequestFilter.java
+++ b/myconext-server/src/main/java/myconext/security/GuestIdpAuthenticationRequestFilter.java
@@ -365,7 +365,8 @@ public class GuestIdpAuthenticationRequestFilter extends OncePerRequestFilter {
                 hasRequiredIapAssurance(user, authenticationContextClassReferenceValues);
     }
 
-    private boolean hasRequiredIapAssurance(User user, List<String> authenticationContextClassReferenceValues) {
+    // Todo Consider moving to ACR.java
+    public static boolean hasRequiredIapAssurance(User user, List<String> authenticationContextClassReferenceValues) {
         boolean highRequired = ACR.containsAcr(authenticationContextClassReferenceValues, ACR.IAP_HIGH);
         boolean mediumRequired = ACR.containsAcr(authenticationContextClassReferenceValues, ACR.IAP_MEDIUM);
         if (!highRequired && !mediumRequired) {
@@ -935,7 +936,7 @@ public class GuestIdpAuthenticationRequestFilter extends OncePerRequestFilter {
         return attributes;
     }
 
-    private List<String> eduPersonAssurances(User user) {
+    private static List<String> eduPersonAssurances(User user) {
         //we need a mutable list
         List<LinkedAccount> linkedAccounts = user.getLinkedAccounts();
         List<String> eduPersonAssuranceIdP = linkedAccounts.stream()

--- a/myconext-server/src/main/java/myconext/security/SecurityConfiguration.java
+++ b/myconext-server/src/main/java/myconext/security/SecurityConfiguration.java
@@ -112,11 +112,15 @@ public class SecurityConfiguration {
                             @Value("${account_linking_context_class_ref.validate_names}") String validateNames,
                             @Value("${account_linking_context_class_ref.validate_names_external}") String validateNamesExternal,
                             @Value("${account_linking_context_class_ref.affiliation_student}") String affiliationStudent,
+                            @Value("${account_linking_context_class_ref.iap_medium}") String iapMedium,
+                            @Value("${account_linking_context_class_ref.iap_high}") String iapHigh,
                             @Value("${account_linking_context_class_ref.profile_mfa}") String profileMfa,
                             @Value("${account_linking_context_class_ref.linked_institution_mfa}") String linkedInstitutionMfa,
                             @Value("${account_linking_context_class_ref.validate_names_mfa}") String validateNamesMfa,
                             @Value("${account_linking_context_class_ref.validate_names_external_mfa}") String validateNamesExternalMfa,
                             @Value("${account_linking_context_class_ref.affiliation_student_mfa}") String affiliationStudentMfa,
+                            @Value("${account_linking_context_class_ref.iap_medium_mfa}") String iapMediumMfa,
+                            @Value("${account_linking_context_class_ref.iap_high_mfa}") String iapHighMfa,
                             @Value("${linked_accounts.expiry-duration-days-non-validated}") long expiryNonValidatedDurationDays,
                             @Value("${sso_mfa_duration_seconds}") long ssoMFADurationSeconds,
                             @Value("${mobile_app_rp_entity_id}") String mobileAppROEntityId,
@@ -141,11 +145,15 @@ public class SecurityConfiguration {
                     validateNames,
                     validateNamesExternal,
                     affiliationStudent,
+                    iapMedium,
+                    iapHigh,
                     profileMfa,
                     linkedInstitutionMfa,
                     validateNamesMfa,
                     validateNamesExternalMfa,
-                    affiliationStudentMfa
+                    affiliationStudentMfa,
+                    iapMediumMfa,
+                    iapHighMfa
             );
             String[] keys = this.getKeys(certificatePath, privateKeyPath);
             final List<SAMLServiceProvider> serviceProviders = new ArrayList<>();

--- a/myconext-server/src/main/resources/application.yml
+++ b/myconext-server/src/main/resources/application.yml
@@ -257,11 +257,15 @@ account_linking_context_class_ref:
   validate_names: https://eduid.nl/trust/validate-names
   validate_names_external: https://eduid.nl/trust/validate-names-external
   affiliation_student: https://eduid.nl/trust/affiliation-student
+  iap_medium: https://refeds.org/assurance/IAP/medium
+  iap_high: https://refeds.org/assurance/IAP/high
   profile_mfa: https://refeds.org/profile/mfa
   linked_institution_mfa: https://eduid.nl/trust/linked-institution/mfa
   validate_names_mfa: https://eduid.nl/trust/validate-names/mfa
   validate_names_external_mfa: https://eduid.nl/trust/validate-names-external/mfa
   affiliation_student_mfa: https://eduid.nl/trust/affiliation-student/mfa
+  iap_medium_mfa: https://refeds.org/assurance/IAP/medium/mfa
+  iap_high_mfa: https://refeds.org/assurance/IAP/high/mfa
 
 account_linking:
   myconext_sp_entity_id: https://mijn.test2.eduid.nl/shibboleth

--- a/myconext-server/src/test/java/myconext/security/ACRTest.java
+++ b/myconext-server/src/test/java/myconext/security/ACRTest.java
@@ -323,6 +323,24 @@ class ACRTest {
     }
 
     @Test
+    void testExplanationKeyWord_IapMedium() {
+        List<String> acrValues = Collections.singletonList(ACR.IAP_MEDIUM);
+
+        String result = ACR.explanationKeyWord(acrValues, true);
+
+        assertEquals("any_link", result);
+    }
+
+    @Test
+    void testExplanationKeyWord_IapHigh() {
+        List<String> acrValues = Collections.singletonList(ACR.IAP_HIGH);
+
+        String result = ACR.explanationKeyWord(acrValues, true);
+
+        assertEquals("any_link", result);
+    }
+
+    @Test
     void testExplanationKeyWord_RandomText() {
         List<String> acrValues = Collections.singletonList("unknown-acr");
 

--- a/myconext-server/src/test/java/myconext/security/ACRTest.java
+++ b/myconext-server/src/test/java/myconext/security/ACRTest.java
@@ -21,11 +21,15 @@ class ACRTest {
     private String originalValidateNames;
     private String originalValidateNamesExternal;
     private String originalAffiliationStudent;
+    private String originalIapMedium;
+    private String originalIapHigh;
     private String originalProfileMfa;
     private String originalLinkedInstitutionMfa;
     private String originalValidateNamesMfa;
     private String originalValidateNamesExternalMfa;
     private String originalAffiliationStudentMfa;
+    private String originalIapMediumMfa;
+    private String originalIapHighMfa;
 
     @BeforeEach
     void snapshotAcrStaticState() {
@@ -33,11 +37,15 @@ class ACRTest {
         originalValidateNames = ACR.VALIDATE_NAMES;
         originalValidateNamesExternal = ACR.VALIDATE_NAMES_EXTERNAL;
         originalAffiliationStudent = ACR.AFFILIATION_STUDENT;
+        originalIapMedium = ACR.IAP_MEDIUM;
+        originalIapHigh = ACR.IAP_HIGH;
         originalProfileMfa = ACR.PROFILE_MFA;
         originalLinkedInstitutionMfa = ACR.LINKED_INSTITUTION_MFA;
         originalValidateNamesMfa = ACR.VALIDATE_NAMES_MFA;
         originalValidateNamesExternalMfa = ACR.VALIDATE_NAMES_EXTERNAL_MFA;
         originalAffiliationStudentMfa = ACR.AFFILIATION_STUDENT_MFA;
+        originalIapMediumMfa = ACR.IAP_MEDIUM_MFA;
+        originalIapHighMfa = ACR.IAP_HIGH_MFA;
     }
 
     @AfterEach
@@ -47,11 +55,15 @@ class ACRTest {
                 originalValidateNames,
                 originalValidateNamesExternal,
                 originalAffiliationStudent,
+                originalIapMedium,
+                originalIapHigh,
                 originalProfileMfa,
                 originalLinkedInstitutionMfa,
                 originalValidateNamesMfa,
                 originalValidateNamesExternalMfa,
-                originalAffiliationStudentMfa
+                originalAffiliationStudentMfa,
+                originalIapMediumMfa,
+                originalIapHighMfa
         );
     }
 
@@ -325,11 +337,13 @@ class ACRTest {
         List<String> result = ACR.allAccountLinkingContextClassReferences();
 
         // Then;
-        assertEquals(4, result.size());
+        assertEquals(6, result.size());
         assertTrue(result.contains(ACR.VALIDATE_NAMES));
         assertTrue(result.contains(ACR.VALIDATE_NAMES_EXTERNAL));
         assertTrue(result.contains(ACR.LINKED_INSTITUTION));
         assertTrue(result.contains(ACR.AFFILIATION_STUDENT));
+        assertTrue(result.contains(ACR.IAP_MEDIUM));
+        assertTrue(result.contains(ACR.IAP_HIGH));
     }
 
     @Test
@@ -339,11 +353,15 @@ class ACRTest {
         String newValidateNames = "https://test.nl/validate-names";
         String newExternalValidateNames = "https://test.nl/validate-names-external";
         String newAffiliationStudent = "https://test.nl/affiliation-student";
+        String newIapMedium = "https://test.nl/iap/medium";
+        String newIapHigh = "https://test.nl/iap/high";
         String newProfileMfa = "https://refeds.org/profile/mfa";
         String newLinkedInstitutionMfa = "https://test.nl/linked-institution/mfa";
         String newValidateNamesMfa = "https://test.nl/validate-names/mfa";
         String newExternalValidateNamesMfa = "https://test.nl/validate-names-external/mfa";
         String newAffiliationStudentMfa = "https://test.nl/affiliation-student/mfa";
+        String newIapMediumMfa = "https://test.nl/iap/medium/mfa";
+        String newIapHighMfa = "https://test.nl/iap/high/mfa";
 
         // When
         ACR.initialize(
@@ -351,11 +369,15 @@ class ACRTest {
                 newValidateNames,
                 newExternalValidateNames,
                 newAffiliationStudent,
+                newIapMedium,
+                newIapHigh,
                 newProfileMfa,
                 newLinkedInstitutionMfa,
                 newValidateNamesMfa,
                 newExternalValidateNamesMfa,
-                newAffiliationStudentMfa
+                newAffiliationStudentMfa,
+                newIapMediumMfa,
+                newIapHighMfa
                 );
 
         // Then
@@ -363,11 +385,15 @@ class ACRTest {
         assertEquals(newValidateNames, ACR.VALIDATE_NAMES);
         assertEquals(newExternalValidateNames, ACR.VALIDATE_NAMES_EXTERNAL);
         assertEquals(newAffiliationStudent, ACR.AFFILIATION_STUDENT);
+        assertEquals(newIapMedium, ACR.IAP_MEDIUM);
+        assertEquals(newIapHigh, ACR.IAP_HIGH);
         assertEquals(newProfileMfa, ACR.PROFILE_MFA);
         assertEquals(newLinkedInstitutionMfa, ACR.LINKED_INSTITUTION_MFA);
         assertEquals(newValidateNamesMfa, ACR.VALIDATE_NAMES_MFA);
         assertEquals(newExternalValidateNamesMfa, ACR.VALIDATE_NAMES_EXTERNAL_MFA);
         assertEquals(newAffiliationStudentMfa, ACR.AFFILIATION_STUDENT_MFA);
+        assertEquals(newIapMediumMfa, ACR.IAP_MEDIUM_MFA);
+        assertEquals(newIapHighMfa, ACR.IAP_HIGH_MFA);
 
     }
 }


### PR DESCRIPTION
Adds ACR's (Including the MFA variants):
"https://refeds.org/assurance/IAP/medium"
"https://refeds.org/assurance/IAP/high"

This PR includes handeling these levels by showing the proper step-up screens.

In case of `/high` the user will get any possible way to connect to an institution. If the attempted connection fails due to insufficient level, the user will get another step-up screen that only shows the "external-validation" options (iDin etc)